### PR TITLE
Fix preprocess.py path

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ cd ../..
 
 
 TEXT=examples/language_model/wikitext-103
-python preprocess.py \
+python fairseq_cli/preprocess.py \
     --only-source \
     --trainpref $TEXT/wiki.train.tokens \
     --validpref $TEXT/wiki.valid.tokens \


### PR DESCRIPTION
There is no preprocess.py in the root directory, so I assume the correct path must be fairseq_cli/preprocess.py.